### PR TITLE
Fixing the bower and npm install instructions

### DIFF
--- a/gettingStarted.html
+++ b/gettingStarted.html
@@ -26,7 +26,7 @@
 
 		<p>
 			You can download both files from <a href='https://github.com/pdfmake/pdfmake/tree/master/build'>github</a> or with bower:
-			<pre class='code'> bower install pdfmake</pre>
+			<pre class='code'> bower install pdfmake-dist</pre>
 		</p>
 
 		<p>In the latter case you'll find the files under <strong>bower_components/pdfmake/build/</strong></p>
@@ -41,7 +41,7 @@
 		This document will walk you through the basics of pdfmake and will show you how to create PDF files under NodeJS (<a ng-click='showNodeVersion = false'>switch back to browser-based version</a>)
 		<br/><br/>
 		1. Install <strong>pdfmake</strong> with npm:
-		<pre class='code'> npm install pdfmake</pre>
+		<pre class='code'> npm install pdfmake-node</pre>
 		<br/>
 		2. Create fonts directory and copy TTF fonts you'd like to use
 		TODO


### PR DESCRIPTION
Currently anyone who even ends up on these pages wouldn't install this repo, because pdfmake on npm and bower point to the older repo.

Making it point to the correct repo.